### PR TITLE
Support key context on objects without LocalizeStringEvent [STRINGS-248]

### DIFF
--- a/Runtime/PhraseKeyContext.cs
+++ b/Runtime/PhraseKeyContext.cs
@@ -7,7 +7,7 @@ using UnityEngine.Localization.Tables;
 namespace Phrase
 {
   [ExecuteInEditMode]
-  [RequireComponent(typeof(LocalizeStringEvent))]
+  // [RequireComponent(typeof(LocalizeStringEvent))]
   [AddComponentMenu("Localization/Phrase Key Context")]
   public class PhraseKeyContext : MonoBehaviour
   {


### PR DESCRIPTION
A text game object (such as TMP) can be translated by assigning a LocalizeStringEvent to it, but also implicitly, by setting up "Track Changes" in "Localization Scene Controls", which automatically adds new keys to tables whenever a new object is added and its text updated.
In order to cover these objects with Phrase Context, we need to look up their keys slightly differently. This PR addresses that.

https://phrase.atlassian.net/browse/STRINGS-248