### PR TITLE
Optimize filtering, change key prefix behavior

### DIFF
--- a/Editor/PhraseCsvColumns.cs
+++ b/Editor/PhraseCsvColumns.cs
@@ -74,10 +74,6 @@ namespace Phrase
         public override void WriteRow(SharedTableData.SharedTableEntry keyEntry, IList<StringTableEntry> tableEntries, CsvWriter writer)
         {
             string keyName = keyEntry.Key;
-            if (!string.IsNullOrEmpty(m_KeyPrefix))
-            {
-                keyName = m_KeyPrefix + keyName;
-            }
             writer.WriteField(keyName);
 
             var metadata = keyEntry.Metadata.GetMetadata<PhraseMetadata>();
@@ -109,8 +105,6 @@ namespace Phrase
             {
                 if (!keyName.StartsWith(m_KeyPrefix))
                     return null;
-                // strip the prefix
-                keyName = keyName.Substring(m_KeyPrefix.Length);
             }
             return m_SharedTableData.GetEntry(keyName) ?? m_SharedTableData.AddKey(keyName);
         }


### PR DESCRIPTION
* Object filtering should happen only when the selection changes, not upon every redraw of Phrase window
* Key prefix shouldn't be stripped/appended upon push/pull, just filtered on pull
* Using Transform instead of GameObject
* Optimize evaluating key name, provider, shared table etc, by avoiding re calculating the same objects multiple times (although the rendering is still slow for some reason)