### PR TITLE
Unity 2019 compatibility

### DIFF
--- a/Editor/Phrase.Editor.asmdef
+++ b/Editor/Phrase.Editor.asmdef
@@ -18,6 +18,12 @@
     ],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "Unity",
+            "expression": "2020.3",
+            "define": "ENABLE_PROPERTY_VARIANTS"
+        }
+    ],
     "noEngineReferences": false
 }

--- a/Editor/PhraseClient.cs
+++ b/Editor/PhraseClient.cs
@@ -131,7 +131,7 @@ namespace Phrase
             {
                 url += "&tags=" + HttpUtility.UrlEncode(tag);
             }
-            using HttpResponseMessage response = await Client.GetAsync(url);
+            HttpResponseMessage response = await Client.GetAsync(url);
             response.EnsureSuccessStatusCode();
             return await response.Content.ReadAsStringAsync();
         }
@@ -140,7 +140,7 @@ namespace Phrase
         public async void UpdateLocalesList(string projectID, List<Locale> locales)
         {
             string url = string.Format("projects/{0}/locales", projectID);
-            using HttpResponseMessage response = await Client.GetAsync(url);
+            HttpResponseMessage response = await Client.GetAsync(url);
             response.EnsureSuccessStatusCode();
             string jsonResponse = await response.Content.ReadAsStringAsync();
             locales.Clear();
@@ -163,7 +163,7 @@ namespace Phrase
 
             do
             {
-                using HttpResponseMessage response = await Client.GetAsync($"projects?per_page=100&page={page}");
+                HttpResponseMessage response = await Client.GetAsync($"projects?per_page=100&page={page}");
                 response.EnsureSuccessStatusCode();
                 string jsonResponse = await response.Content.ReadAsStringAsync();
                 currentBatch = JsonConvert.DeserializeObject<List<Project>>(jsonResponse);
@@ -231,7 +231,7 @@ namespace Phrase
         public async Task<Key> GetKey(string projectID, string keyName)
         {
             string url = string.Format($"projects/{{0}}/keys?q=name:{Uri.EscapeDataString(keyName)}", projectID);
-            using HttpResponseMessage response = await Client.GetAsync(url);
+            HttpResponseMessage response = await Client.GetAsync(url);
             response.EnsureSuccessStatusCode();
             string jsonResponse = await response.Content.ReadAsStringAsync();
             List<Key> keys = JsonConvert.DeserializeObject<List<Key>>(jsonResponse);

--- a/Editor/PhraseEditor.cs
+++ b/Editor/PhraseEditor.cs
@@ -5,9 +5,11 @@ using UnityEditor;
 using UnityEngine;
 using UnityEngine.Localization;
 using UnityEngine.Localization.Components;
+using UnityEngine.Localization.Tables;
+#if ENABLE_PROPERTY_VARIANTS
 using UnityEngine.Localization.PropertyVariants;
 using UnityEngine.Localization.PropertyVariants.TrackedProperties;
-using UnityEngine.Localization.Tables;
+#endif
 
 namespace Phrase
 {
@@ -28,6 +30,7 @@ namespace Phrase
         return localizeStringEvent.StringReference;
       }
 
+#if ENABLE_PROPERTY_VARIANTS
       var gameObjectLocalizer = gameObject.GetComponentInParent<GameObjectLocalizer>();
       if (gameObjectLocalizer != null)
       {
@@ -41,6 +44,7 @@ namespace Phrase
           }
         }
       }
+#endif
 
       return null;
     }

--- a/Editor/PhraseProvider.cs
+++ b/Editor/PhraseProvider.cs
@@ -44,13 +44,13 @@ namespace Phrase
 
         public string m_ApiKey;
 
-        public List<Project> Projects = new();
+        public List<Project> Projects = new List<Project>();
 
-        public List<Locale> Locales = new();
+        public List<Locale> Locales = new List<Locale>();
 
-        public List<string> LocaleIdsToPull = new();
+        public List<string> LocaleIdsToPull = new List<string>();
 
-        public List<string> LocaleIdsToPush = new();
+        public List<string> LocaleIdsToPush = new List<string>();
 
         public string m_selectedAccountId = null;
 
@@ -62,14 +62,23 @@ namespace Phrase
 
         public string Token => UseOauth ? m_OauthToken : m_ApiKey;
 
-        private PhraseClient Client => new(this);
+        private PhraseClient Client => new PhraseClient(this);
 
-        private string StringsAppHost => m_Environment switch
+        private string StringsAppHost
         {
-            "EU" => "https://app.phrase.com",
-            "US" => "https://us.app.phrase.com",
-            _ => Regex.IsMatch(m_ApiUrl, "localhost:3000") ? "http://localhost:3000" : "https://app.phrase-qa.com",
-        };
+            get
+            {
+                switch (m_Environment)
+                {
+                    case "EU":
+                        return "https://app.phrase.com";
+                    case "US":
+                        return "https://us.app.phrase.com";
+                    default:
+                        return Regex.IsMatch(m_ApiUrl, "localhost:3000") ? "http://localhost:3000" : "https://app.phrase-qa.com";
+                }
+            }
+        }
 
         public void Log(string message)
         {


### PR DESCRIPTION
Seems that older Unity versions use older C#, not allowing for some syntax that we were using in the plugin.
Also, parts of Unity Localization package aren't exposed to versions before 2020.3. I managed to selectively disable part of the plugin relying on these classes so that the plugin still runs in older versions, without affecting the functionality in the newer versions.

Would be nice for this to be QA-ed.