### PR TITLE
Address UE2021 compatibility and project building issues #STRINGS-1364

### DIFF
--- a/Editor/Phrase.Editor.asmdef
+++ b/Editor/Phrase.Editor.asmdef
@@ -9,7 +9,9 @@
         "Unity.EditorCoroutines.Editor",
         "Unity.Addressables.Editor"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": true,

--- a/Editor/PhraseClient.cs
+++ b/Editor/PhraseClient.cs
@@ -129,7 +129,7 @@ namespace Phrase
             string url = string.Format("projects/{0}/locales/{1}/download?file_format=csv&format_options%5Bexport_max_characters_allowed%5D=true&format_options%5Bexport_key_id%5D=true&include_empty_translations=true", projectID, localeID);
             if (tag != null)
             {
-                url += "&tags=" + HttpUtility.UrlEncode(tag);
+                url += "&tags=" + Uri.EscapeDataString(tag);
             }
             HttpResponseMessage response = await Client.GetAsync(url);
             response.EnsureSuccessStatusCode();

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://www.phrase.com"
   },
   "dependencies": {
-    "com.unity.localization": "1.5.0",
+    "com.unity.localization": "1.3.2",
     "com.unity.editorcoroutines": "1.0.0"
   }
 }


### PR DESCRIPTION
Addresses the following problems:

* Unity Editor 2021 compatibility due to Localization version mismatch
* Building game project failing due to platforms in assembly definition