### PR TITLE
Use locale name when pushing to Phrase

### DIFF
--- a/Editor/PhraseClient.cs
+++ b/Editor/PhraseClient.cs
@@ -173,7 +173,7 @@ namespace Phrase
             } while (currentBatch.Count == 100);  // Continue if a full batch is returned
         }
 
-        public async void UploadFile(string path, string projectID, string localeID, string localeCode, bool autoTranslate, string tag)
+        public async void UploadFile(string path, string projectID, string localeID, string localeName, bool autoTranslate, string tag)
         {
             string url = string.Format("projects/{0}/uploads", projectID);
             NameValueCollection nvc = new NameValueCollection
@@ -182,7 +182,7 @@ namespace Phrase
                 { "file_format", "csv" },
                 { "update_descriptions", "true" },
                 { "update_translations", "true" },
-                { $"locale_mapping[{localeCode}]", "4" },
+                { $"locale_mapping[{localeName}]", "4" },
                 { "format_options[key_index]", "1" },
                 { "format_options[comment_index]", "2" },
                 { "format_options[max_characters_allowed_column]", "3" },

--- a/Editor/PhraseProvider.cs
+++ b/Editor/PhraseProvider.cs
@@ -275,7 +275,7 @@ namespace Phrase
                             string keyPrefix = phraseExtension.m_identifierType == TableIdentifierType.KeyPrefix ? phraseExtension.m_identifier : null;
                             Csv.Export(stream, collection, ColumnMappings(locale, keyPrefix));
                         }
-                        Client.UploadFile(path, m_selectedProjectId, locale.id, locale.code, false, tag);
+                        Client.UploadFile(path, m_selectedProjectId, locale.id, locale.name, false, tag);
                         if (File.Exists(path)) File.Delete(path);
                     }
                 }
@@ -299,7 +299,7 @@ namespace Phrase
                 },
                 new LocaleColumns {
                     LocaleIdentifier = locale.code,
-                    FieldName = locale.code
+                    FieldName = locale.name
                 },
             };
         }


### PR DESCRIPTION
Previously we were using locale code as the `locale_mapping` identifier when pushing to Phrase. This was causing a new locale to be created if the Phrase locale name doesn't match the locale code.

This PR changes that so that the locale name will be used as identifier instead. Also, the column header in the uploaded CSV is adjusted accordingly.

https://phrase.atlassian.net/browse/STRINGS-1365