### PR TITLE
Do not refetch locales whenever provider is shown

### DIFF
--- a/Editor/PhraseProvider.cs
+++ b/Editor/PhraseProvider.cs
@@ -441,8 +441,6 @@ namespace Phrase
             serializedObject.ApplyModifiedProperties();
         }
 
-        private string selectedProjectName;
-
         private string TruncateWithEllipsis(string input, int maxLength)
         {
             if (string.IsNullOrEmpty(input) || input.Length <= maxLength)
@@ -540,9 +538,8 @@ namespace Phrase
             if (selectedProjectIndex >= 0 && selectedProjectIndex < filteredProjects.Length)
             {
                 var selectedProject = filteredProjects[selectedProjectIndex];
-                if (selectedProjectName != selectedProject.name)
+                if (phraseProvider.m_selectedProjectId != selectedProject.id)
                 {
-                    selectedProjectName = selectedProject.name;
                     phraseProvider.m_selectedProjectId = selectedProject.id;
                     phraseProvider.m_selectedAccountId = selectedProject.account.id;
                     phraseProvider.FetchLocales();


### PR DESCRIPTION
Fixing bug that caused locale list to be re-fetched from Phrase whenever the provider is re-drawn. This also caused the number of selected items in "Pull Languages" list to be reset to 0.

https://phrase.atlassian.net/browse/STRINGS-1365