### PR TITLE
Key prefix constraint push/pull improvements

### DIFF
--- a/Editor/PhraseClient.cs
+++ b/Editor/PhraseClient.cs
@@ -124,12 +124,16 @@ namespace Phrase
             Client.BaseAddress = new Uri(ApiUrl);
         }
 
-        public async Task<string> DownloadLocale(string projectID, string localeID, string tag)
+        public async Task<string> DownloadLocale(string projectID, string localeID, string tag, string keyPrefix)
         {
             string url = string.Format("projects/{0}/locales/{1}/download?file_format=csv&format_options%5Bexport_max_characters_allowed%5D=true&format_options%5Bexport_key_id%5D=true&include_empty_translations=true", projectID, localeID);
             if (tag != null)
             {
-                url += "&tags=" + Uri.EscapeDataString(tag);
+                url += "&tags=" + WebUtility.UrlEncode(tag);
+            }
+            if (keyPrefix != null)
+            {
+                url += "&filter_by_prefix=true&translation_key_prefix=" + WebUtility.UrlEncode(keyPrefix);
             }
             HttpResponseMessage response = await Client.GetAsync(url);
             response.EnsureSuccessStatusCode();
@@ -230,7 +234,7 @@ namespace Phrase
 
         public async Task<Key> GetKey(string projectID, string keyName)
         {
-            string url = string.Format($"projects/{{0}}/keys?q=name:{Uri.EscapeDataString(keyName)}", projectID);
+            string url = string.Format($"projects/{{0}}/keys?q=name:{WebUtility.UrlEncode(keyName)}", projectID);
             HttpResponseMessage response = await Client.GetAsync(url);
             response.EnsureSuccessStatusCode();
             string jsonResponse = await response.Content.ReadAsStringAsync();

--- a/Editor/PhraseCsvColumns.cs
+++ b/Editor/PhraseCsvColumns.cs
@@ -74,6 +74,8 @@ namespace Phrase
         public override void WriteRow(SharedTableData.SharedTableEntry keyEntry, IList<StringTableEntry> tableEntries, CsvWriter writer)
         {
             string keyName = keyEntry.Key;
+            if (!string.IsNullOrEmpty(m_KeyPrefix))
+                keyName = m_KeyPrefix + keyName;
             writer.WriteField(keyName);
 
             var metadata = keyEntry.Metadata.GetMetadata<PhraseMetadata>();
@@ -101,11 +103,6 @@ namespace Phrase
             string keyName = reader.GetField(m_KeyNameIndex);
             if (string.IsNullOrEmpty(keyName))
                 return null;
-            if (!string.IsNullOrEmpty(m_KeyPrefix))
-            {
-                if (!keyName.StartsWith(m_KeyPrefix))
-                    return null;
-            }
             return m_SharedTableData.GetEntry(keyName) ?? m_SharedTableData.AddKey(keyName);
         }
     }

--- a/Editor/PhraseProvider.cs
+++ b/Editor/PhraseProvider.cs
@@ -309,10 +309,10 @@ namespace Phrase
             Log("Downloading locale " + selectedLocale.code);
             var phraseExtension = collection.Extensions.FirstOrDefault(e => e is PhraseExtension) as PhraseExtension;
             string tag = phraseExtension.m_identifierType == TableIdentifierType.Tag ? phraseExtension.m_identifier : null;
-            var csvContent = await Client.DownloadLocale(m_selectedProjectId, selectedLocale.id, tag);
+            string keyPrefix = phraseExtension.m_identifierType == TableIdentifierType.KeyPrefix ? phraseExtension.m_identifier : null;
+            var csvContent = await Client.DownloadLocale(m_selectedProjectId, selectedLocale.id, tag, keyPrefix);
             using (var reader = new StringReader(csvContent))
             {
-                string keyPrefix = phraseExtension.m_identifierType == TableIdentifierType.KeyPrefix ? phraseExtension.m_identifier : null;
                 var columnMappings = ColumnMappings(selectedLocale, keyPrefix);
                 Csv.ImportInto(reader, collection, columnMappings);
             }

--- a/README.md
+++ b/README.md
@@ -37,13 +37,19 @@ You can perform push/pull from Phrase Provider screen, but also from “Phrase E
 
 ![Phrase Extension on a String Table Collection](docs/phrase_extension.png)
 
-There you push/pull only the target table. This extension also enables you to constrain the subset of keys that will be pushed/pulled to the particular table, by selecting the “Identifyer Type”:
+There you push/pull only from/to the table in question.
 
-* “Key Prefix” – only keys with the given prefix in their names will be imported to the target table.
+### Working with multiple String Table Collections
 
-* “Tag” – only keys with matching tag will be imported to the target table. Upon pushing, all keys from this table will get this tag assigned.
+It's common that a user might organize their translations into multiple String Table Collections, for example based on the game section or the type of the items referred to (e.g. Weapons, Items, Characters etc). In that case one would want to connect the collection with only a subset of all existing [translation keys](https://support.phrase.com/hc/en-us/articles/5784119185436-Keys-Strings) in Phrase Strings. For this purpose, you can use key name prefixes or [key tags](https://support.phrase.com/hc/en-us/articles/5822598372252-Tags-Strings).
 
-* “None” – all keys will be imported to the target table.
+You can constrain the subset of keys that will be pushed/pulled to the particular table, by selecting the “Identifyer Type” in the Collection Extension:
+
+* “Key Prefix” – only keys with the given prefix in their names will be imported (pull) to the target table. The Unity key names will not contain the prefix itself. On push, the whole table will get uploaded to Phrase, and prefix will be automatically appended to the key names.
+
+* “Tag” – only keys with matching tag will be pulled to the target table. Upon pushing, all keys from this table will get this tag assigned.
+
+* “None” – all Phrase keys will be imported to the target table on pull (this is typical when you have only a single Collection connected with Phrase).
 
 ### Phrase window
 


### PR DESCRIPTION
* Key prefix should not be visible in the table, as it is confusing for the users and not needed
* Clarify behaviour better in the documentation
* Use the backend feature for filtering by prefix on pull

https://phrase.atlassian.net/browse/STRINGS-1366