### PR TITLE
[SCD-269] Fix screenshot uploads for keys without keyIds present in metadata

### DIFF
--- a/Editor/PhraseClient.cs
+++ b/Editor/PhraseClient.cs
@@ -2,9 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
@@ -231,19 +233,37 @@ namespace Phrase
             Client.DeleteAsync(url);
         }
 
-        public async Task<List<Key>> GetKeys(string projectID, List<string> keyNames)
+        public async Task<List<Key>> GetKeysByName(string projectID, List<string> keyNames)
         {
-            string url = string.Format($"projects/{{0}}/keys?q=name:{WebUtility.UrlEncode(string.Join(",", keyNames))}", projectID);
-            HttpResponseMessage response = await Client.GetAsync(url);
-            response.EnsureSuccessStatusCode();
-            string jsonResponse = await response.Content.ReadAsStringAsync();
-            return JsonConvert.DeserializeObject<List<Key>>(jsonResponse);
-        }
+            var allKeys = new List<Key>();
+            if (keyNames == null || keyNames.Count == 0) return allKeys;
+            var escapedNames = keyNames.Select(n => Regex.Replace(n, @"[\\\"" ,]", m => "\\" + m.Value)).ToList();
+            string q = $"name:{string.Join(",", escapedNames)}";
 
-        public async Task<Key> GetKey(string projectID, string keyName)
-        {
-            var keys = await GetKeys(projectID, new List<string> { keyName });
-            return keys.Find(k => k.name == keyName);
+            int page = 0;
+            const int perPage = 100; // Phrase API max per_page is 100
+
+            while (true)
+            {
+                string url = $"projects/{projectID}/keys/search?page={page}&per_page={perPage}";
+                var payload = new { q = q };
+                var content = new StringContent(JsonConvert.SerializeObject(payload), Encoding.UTF8, "application/json");
+
+                HttpResponseMessage response = await Client.PostAsync(url, content);
+                response.EnsureSuccessStatusCode();
+
+                string jsonResponse = await response.Content.ReadAsStringAsync();
+                var batch = JsonConvert.DeserializeObject<List<Key>>(jsonResponse);
+
+                if (batch == null || batch.Count == 0) break;
+
+                allKeys.AddRange(batch);
+
+                if (batch.Count < perPage) break; // no more pages
+                page++;
+            }
+
+            return allKeys;
         }
 
         private async Task<string> HttpUploadFile(string url, string path, string paramName, string contentType, NameValueCollection nvc)

--- a/Editor/PhraseClient.cs
+++ b/Editor/PhraseClient.cs
@@ -231,13 +231,18 @@ namespace Phrase
             Client.DeleteAsync(url);
         }
 
-        public async Task<Key> GetKey(string projectID, string keyName)
+        public async Task<List<Key>> GetKeys(string projectID, List<string> keyNames)
         {
-            string url = string.Format($"projects/{{0}}/keys?q=name:{WebUtility.UrlEncode(keyName)}", projectID);
+            string url = string.Format($"projects/{{0}}/keys?q=name:{WebUtility.UrlEncode(string.Join(",", keyNames))}", projectID);
             HttpResponseMessage response = await Client.GetAsync(url);
             response.EnsureSuccessStatusCode();
             string jsonResponse = await response.Content.ReadAsStringAsync();
-            List<Key> keys = JsonConvert.DeserializeObject<List<Key>>(jsonResponse);
+            return JsonConvert.DeserializeObject<List<Key>>(jsonResponse);
+        }
+
+        public async Task<Key> GetKey(string projectID, string keyName)
+        {
+            var keys = await GetKeys(projectID, new List<string> { keyName });
             return keys.Find(k => k.name == keyName);
         }
 

--- a/Editor/PhraseEditor.cs
+++ b/Editor/PhraseEditor.cs
@@ -102,8 +102,17 @@ namespace Phrase
 
       yield return new WaitForEndOfFrame();
 
-      var groupedObjectsByProvider = translatableObjects.GroupBy(x => x.provider)
-      .ToDictionary(g => g.Key, g => g.Select(x => x.metadata).ToList());
+
+      var groupedObjectsByProvider = translatableObjects
+      .GroupBy(x => x.provider)
+      .ToDictionary(
+        g => g.Key,
+        g => g.Select(x => new KeyScreenshotMeta
+        {
+          name = x.keyName,
+          metadata = x.metadata
+        }).ToList()
+      );
 
       foreach (var group in groupedObjectsByProvider)
       {

--- a/Editor/PhraseProvider.cs
+++ b/Editor/PhraseProvider.cs
@@ -374,8 +374,7 @@ namespace Phrase
             if (metadataWithNoKeyId.Count > 0)
             {
                 Debug.Log("Screenshot upload: KeyId is not present for at least one of the selected keys, fetching metadata from Phrase.");
-                var escapedNames = metadataWithNoKeyId.Select(n => Regex.Replace(n.name, @"[\\\"" ,]", m => "\\" + m.Value)).ToList();
-                var phraseKeys = await Client.GetKeys(m_selectedProjectId, escapedNames);
+                var phraseKeys = await Client.GetKeysByName(m_selectedProjectId, metadataWithNoKeyId.Select(n => n.name).ToList());
                 foreach (var metadata in metadataWithNoKeyId)
                 {
                     var matchingKey = phraseKeys.FirstOrDefault(k => k.name == metadata.name);

--- a/Editor/PhraseProvider.cs
+++ b/Editor/PhraseProvider.cs
@@ -374,7 +374,8 @@ namespace Phrase
             if (metadataWithNoKeyId.Count > 0)
             {
                 Debug.Log("Screenshot upload: KeyId is not present for at least one of the selected keys, fetching metadata from Phrase.");
-                var phraseKeys = await Client.GetKeys(m_selectedProjectId, metadataWithNoKeyId.Select(m => m.name).ToList());
+                var escapedNames = metadataWithNoKeyId.Select(n => Regex.Replace(n.name, @"[\\\"" ,]", m => "\\" + m.Value)).ToList();
+                var phraseKeys = await Client.GetKeys(m_selectedProjectId, escapedNames);
                 foreach (var metadata in metadataWithNoKeyId)
                 {
                     var matchingKey = phraseKeys.FirstOrDefault(k => k.name == metadata.name);

--- a/Editor/PhraseProvider.cs
+++ b/Editor/PhraseProvider.cs
@@ -416,7 +416,7 @@ namespace Phrase
 
                     if (metadata.KeyId == "" || metadata.KeyId == null)
                     {
-                        Debug.LogError("KeyId is not present for at least one of the selected keys, please synchronize your keys with Phrase first.");
+                        Debug.LogError("Screenshot upload: KeyId is not present for at least one of the selected keys, please synchronize your keys with Phrase first.");
                         continue;
                     }
 


### PR DESCRIPTION
When a key is created in Unity we don't have the ID of the key locally until a push submits the key to Strings, so all the screenshot marker creations fail until then. 

* When user tries to upload screenshot to a local Unity key that's not pulled from Strings yet,  use List Keys API to fetch the Strings key IDs and populate metadata accordingly.
* Add debug logging and skip when a key that still doesn't have a `KeyId` in its metadata.

https://phrase.atlassian.net/browse/SCD-269